### PR TITLE
Added Parser for generic ASTs

### DIFF
--- a/MetaLogic.cabal
+++ b/MetaLogic.cabal
@@ -81,7 +81,7 @@ test-suite MetaLogic-test
     -- The entrypoint to the test suite.
     main-is:          Spec.hs
 
-    other-modules:    PropositionalLogicSpec
+    other-modules:    PropositionalLogicSpec, ParserSpec
 
     -- Test dependencies.
     build-depends:    

--- a/MetaLogic.cabal
+++ b/MetaLogic.cabal
@@ -51,7 +51,7 @@ extra-source-files:
 
 library
     -- Modules exported by the library.
-    exposed-modules:  Main, PropositionalLogic, Assignment
+    exposed-modules:  Main, PropositionalLogic, Assignment, Parser
 
     -- Modules included in this library but not exported.
     other-modules:    OperatorSymbols
@@ -60,7 +60,7 @@ library
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.14.1.0, containers, bifunctors
+    build-depends:    base ^>=4.14.1.0, containers, parsec
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -33,7 +33,9 @@ ast :: Stream s m String => ParsecT s u m (AST a)
 ast = maybeWrapped (leaf <|> node)
 
 leafOrNode :: Stream s m String => ParsecT s u m (AST a)
-leafOrNode = leaf <|> wrapped (maybeWrapped node)
+leafOrNode =
+  leaf <|> wrapped (maybeWrapped node)
+    <?> "variable or subtree in parentheses"
 
 leaf :: Stream s m String => ParsecT s u m (AST a)
 leaf = Leaf <$> identifier

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Parser where
+
+import Control.Applicative (liftA2)
+import Data.Sequence as Seq
+import Text.Parsec
+
+data AST a
+  = Variable
+      { variableName :: String
+      }
+  | Operator
+      { operatorName :: String,
+        args :: Seq.Seq (AST a)
+      }
+  deriving (Eq, Show)
+
+ast :: Stream s m Char => ParsecT s u m (AST a)
+ast = variable <|> operator
+
+variable :: Stream s m Char => ParsecT s u m (AST a)
+variable = Variable <$> identifier <?> "single variable"
+
+operator :: Stream s m Char => ParsecT s u m (AST a)
+operator =
+  liftA2 Operator operatorString arguments
+
+arguments :: Stream s m Char => ParsecT s u m (Seq.Seq (AST a))
+arguments =
+  Seq.fromList
+    <$> parenthesized (spaced (ast `sepEndBy` many1 space))
+    <?> "args list in parentheses"
+
+operatorString :: Stream s m Char => ParsecT s u m String
+operatorString =
+  spaced
+    ( symbols
+        <|> parenthesized (spaced identifier <?> "named operator")
+        <?> "operator"
+    )
+
+identifier :: Stream s m Char => ParsecT s u m String
+identifier = many1 letter <> many alphaNum <?> "identifier"
+
+symbols :: Stream s m Char => ParsecT s u m String
+symbols = many1 symbol
+
+symbol :: Stream s m Char => ParsecT s u m Char
+symbol = oneOf ".,:;'/<>?~!@#$%^&*-+=|\\"
+
+parenthesized :: Stream s m Char => ParsecT s u m t -> ParsecT s u m t
+parenthesized = between (char '(') (char ')')
+
+spaced :: Stream s m Char => ParsecT s u m t -> ParsecT s u m t
+spaced = between spaces spaces

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -1,0 +1,91 @@
+module ParserSpec where
+
+import qualified Assignment
+import Control.Monad (liftM2, replicateM)
+import Data.Either (fromRight)
+import qualified Data.List as List
+import qualified Parser
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+newtype Alpha = Alpha {getAlpha :: Char}
+
+newtype AlphaNum = AlphaNum {getAlphaNum :: Char}
+
+newtype Identifier = Identifier {getIdentifier :: String}
+
+newtype Symbol = Symbol {getSymbol :: Char}
+
+newtype OperatorName = OperatorName {getOperatorName :: String}
+
+newtype ASTString = ASTString {getASTString :: String} deriving (Eq, Show)
+
+instance Arbitrary Alpha where
+  arbitrary = oneof $ map (pure . Alpha) (['A' .. 'Z'] ++ ['a' .. 'z'])
+
+instance Arbitrary AlphaNum where
+  arbitrary =
+    oneof $ map (pure . AlphaNum) (['A' .. 'Z'] ++ ['a' .. 'z'] ++ ['0' .. '9'])
+
+instance Arbitrary Symbol where
+  arbitrary = oneof $ map (pure . Symbol) ".,:;'/<>?~!@#$%^&*-+=|\\"
+
+instance Arbitrary Identifier where
+  arbitrary =
+    Identifier
+      <$> liftM2
+        (:)
+        (getAlpha <$> arbitrary)
+        (oneof [pure [], (: []) . getAlphaNum <$> arbitrary])
+
+instance Arbitrary OperatorName where
+  arbitrary = OperatorName <$> sized name'
+    where
+      name' n
+        | n > 2 = name' 2
+        | n == 0 = (: []) . getSymbol <$> arbitrary
+        | n > 0 = liftM2 (:) (getSymbol <$> arbitrary) (name' (n - 1))
+
+instance Arbitrary ASTString where
+  arbitrary = ASTString <$> sized formula'
+    where
+      formula' 0 = leaf'
+      formula' n
+        | n > 0 = oneof [leaf', node' n]
+      leaf' = getIdentifier <$> arbitrary
+      node' n =
+        (\x -> "(" ++ x ++ ")")
+          <$> liftM2
+            (++)
+            ((++ " ") . getOperatorName <$> arbitrary)
+            (List.unwords <$> replicateM (min n 3) (formula' (n `div` 2)))
+
+instance Arbitrary (Parser.AST a) where
+  arbitrary = sized tree'
+    where
+      tree' 0 = leaf'
+      tree' n
+        | n > 0 = oneof [leaf', node' n]
+      leaf' = Parser.Leaf . getIdentifier <$> arbitrary
+      node' n =
+        liftM2
+          Parser.Node
+          (getOperatorName <$> arbitrary)
+          (replicateM (min n 3) (tree' (n `div` 2)))
+
+spec :: Spec
+spec = do
+  describe "Parser.parseAST" $ do
+    prop "show . parseAST == id (for our inputs)" $
+      \x ->
+        show
+          ( fromRight undefined . Parser.parseAST $
+              getASTString x ::
+              Parser.AST Int
+          )
+          == getASTString x
+
+    prop "parseAST . show == id" $
+      \x ->
+        fromRight undefined (Parser.parseAST (show x)) == (x :: Parser.AST Int)


### PR DESCRIPTION
Currently, the parser accepts the grammar
```
<S>           ::= <leaf> | <node> | "(" <S> ")"
<leaf>        ::= <identifier>
<node>        ::= <opname> <args>
<opname>      ::= <symbols> | <identifier> | "(" <opname> ")"
<args>        ::= <leafOrNode> | <leafOrNode> <args>
<leafOrNode>  ::= <leaf> | "(" <node> ")"
<identifier>  ::= <alpha> | <alpha> <alphaNums>
<symbols>     ::= <symbol> | <symbol> <symbols>
<alphaNums>   ::= <alphaNum> | <alphaNum> <alphaNums>
<alphaNum>    ::= ...
<symbol>      ::= ...
```
where `<alphaNum>` recognizes a single alpha numeric character and `<symbol>` recognizes any one character in `.,:;'/<>?~!@#$%^&*-+=|\`. Notice that we do this at the word level (all whitespace is used to make tokens and then we strip it off). For example, the parser sees `"          x      (         yx)        "` as `["x", "(", "yx", ")"]`.

resolves #3 