### PR TITLE
Fixes the Parser to behave more like Haskell code

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1.1.3
       with:
-        ghc-version: '8.10.4'
-        cabal-version: '2.4'
+        ghc-version: '8.10.5'
+        cabal-version: '3.4'
 
     - name: Cache
       uses: actions/cache@v1

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1.1.4
       with:
-        ghc-version: '8.10.5'
+        ghc-version: '8.10.4'
         cabal-version: '3.4'
 
     - name: Cache

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: actions/setup-haskell@v1.1.4
       with:
         ghc-version: '8.10.5'
         cabal-version: '3.4'

--- a/src/AbstractSyntaxTree/Internal.hs
+++ b/src/AbstractSyntaxTree/Internal.hs
@@ -1,0 +1,12 @@
+module AbstractSyntaxTree.Internal where
+
+import qualified Data.Sequence as Seq
+
+data AST a = AST
+  { name :: a,
+    children :: [AST a]
+  }
+  deriving (Eq, Show)
+
+ast :: a -> [AST a] -> AST a
+ast = AST


### PR DESCRIPTION
We now correctly interpret "+ X (- A B C) Y" as the expected tree (i.e. "X", "- A B C" and "Y" are the children of "+"). In particular, this
resolves #9 
