### PR TITLE
Relaxed Parser and Improved Error Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for MetaLogic
 
+## 0.1.4.1 -- 2021-06-18
+
+* Internals of error handling cleaned up
+
 ## 0.1.4.0 -- 2021-06-18
 
 * Logic system for Peano Arithmetic added

--- a/MetaLogic.cabal
+++ b/MetaLogic.cabal
@@ -54,6 +54,7 @@ library
     exposed-modules:  
         Main
       , AbstractSyntaxTree
+      , ErrorHandling
       , Interpreter
       , LogicSystem
       , Parser

--- a/MetaLogic.cabal
+++ b/MetaLogic.cabal
@@ -14,7 +14,7 @@ name:               MetaLogic
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:            0.1.4.0
+version:            0.1.4.1
 
 -- A short (one-line) description of the package.
 synopsis:

--- a/src/AbstractSyntaxTree.hs
+++ b/src/AbstractSyntaxTree.hs
@@ -10,3 +10,6 @@ data AST a = AST
 
 ast :: a -> [AST a] -> AST a
 ast = AST
+
+instance Functor AST where
+  fmap f (AST n as) = AST (f n) (fmap (fmap f) as)

--- a/src/ErrorHandling.hs
+++ b/src/ErrorHandling.hs
@@ -1,0 +1,14 @@
+module ErrorHandling (Error, parseError, interpretError) where
+
+import qualified Text.Parsec as Parsec
+
+data Error
+  = ParseError Parsec.ParseError
+  | InterpretError String
+  deriving (Show)
+
+parseError :: Parsec.ParseError -> Error
+parseError = ParseError
+
+interpretError :: String -> Error
+interpretError = InterpretError

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -13,7 +13,6 @@ import qualified LogicSystem as LS
 class (Ord a, LS.LogicSystem (LogicSystem i)) => Interpreter i a b where
   type LogicSystem i :: *
 
-  -- todo later upgrade this using the Reader type / monad
   operatorByID ::
     i ->
     Map.Map
@@ -33,6 +32,7 @@ interpret i (AST.AST n children) = case Map.lookup n (operatorByID i) of
   Nothing -> pure $ variableFromID i n
   (Just op) -> mapM (interpret i) children >>= op
 
+-- Convenience constructors
 makeConstant ::
   LS.Formula t a ->
   String ->

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -7,9 +7,10 @@ module Interpreter where
 import qualified AbstractSyntaxTree as AST
 import Data.Functor ((<&>))
 import qualified Data.Map as Map
+import qualified ErrorHandling as EH
 import qualified LogicSystem as LS
 
-class (Ord a, LS.LogicSystem (LogicSystem i)) => Interpreter i a where
+class (Ord a, LS.LogicSystem (LogicSystem i)) => Interpreter i a b where
   type LogicSystem i :: *
 
   -- todo later upgrade this using the Reader type / monad
@@ -17,19 +18,17 @@ class (Ord a, LS.LogicSystem (LogicSystem i)) => Interpreter i a where
     i ->
     Map.Map
       a
-      ( [LS.Formula (LogicSystem i) a] ->
-        Either Interpreter.InterpretError (LS.Formula (LogicSystem i) a)
+      ( [LS.Formula (LogicSystem i) b] ->
+        Either EH.Error (LS.Formula (LogicSystem i) b)
       )
   variableFromID ::
-    i -> a -> LS.Formula (LogicSystem i) a
-
-newtype InterpretError = InterpretError String deriving (Show)
+    i -> a -> LS.Formula (LogicSystem i) b
 
 interpret ::
-  (Show a, Interpreter i a) =>
+  Interpreter i a b =>
   i ->
   AST.AST a ->
-  Either InterpretError (LS.Formula (LogicSystem i) a)
+  Either EH.Error (LS.Formula (LogicSystem i) b)
 interpret i (AST.AST n children) = case Map.lookup n (operatorByID i) of
   Nothing -> pure $ variableFromID i n
   (Just op) -> mapM (interpret i) children >>= op
@@ -38,31 +37,31 @@ makeConstant ::
   LS.Formula t a ->
   String ->
   [LS.Formula t a] ->
-  Either InterpretError (LS.Formula t a)
+  Either EH.Error (LS.Formula t a)
 makeConstant op _ [] = Right op
 makeConstant _ name _ =
-  Left $ InterpretError $ name ++ " doesn't expect children"
+  Left $ EH.interpretError $ name ++ " doesn't expect children"
 
 makeUnary ::
   (LS.Formula t a -> LS.Formula t a) ->
   String ->
   [LS.Formula t a] ->
-  Either InterpretError (LS.Formula t a)
+  Either EH.Error (LS.Formula t a)
 makeUnary _ name [] =
-  Left $ InterpretError $ name ++ " expects 1 child; recieved none"
+  Left $ EH.interpretError $ name ++ " expects 1 child; recieved none"
 makeUnary op _ [x] = Right $ op x
 makeUnary _ name _ =
-  Left $ InterpretError $ name ++ " expects 1 child; recieved multiple"
+  Left $ EH.interpretError $ name ++ " expects 1 child; recieved multiple"
 
 makeBinary ::
   (LS.Formula t a -> LS.Formula t a -> LS.Formula t a) ->
   String ->
   [LS.Formula t a] ->
-  Either InterpretError (LS.Formula t a)
+  Either EH.Error (LS.Formula t a)
 makeBinary _ name [] =
-  Left $ InterpretError $ name ++ " expects 2 children; recieved none"
+  Left $ EH.interpretError $ name ++ " expects 2 children; recieved none"
 makeBinary _ name [_] =
-  Left $ InterpretError $ name ++ " expects 2 children; recieved 1"
+  Left $ EH.interpretError $ name ++ " expects 2 children; recieved 1"
 makeBinary op _ [x, y] = Right $ op x y
 makeBinary _ name _ =
-  Left $ InterpretError $ name ++ " expects 2 children; recieved 3 or more"
+  Left $ EH.interpretError $ name ++ " expects 2 children; recieved 3 or more"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,7 +1,9 @@
 module Main where
 
+import Control.Monad ((<=<), (>=>))
 import Data.Either (fromRight)
 import qualified Data.Set as Set
+import qualified ErrorHandling as EH
 import Interpreter (interpret)
 import qualified LogicSystem as LS
 import Parser (parseAST)
@@ -11,22 +13,23 @@ import PropositionalLogic
 main :: IO ()
 main = putStrLn "Main does run"
 
-parseAsPropFormula :: String -> Formula PropositionalLogic String
+parseAsPropFormula ::
+  String -> Either EH.Error (Formula PropositionalLogic String)
 parseAsPropFormula =
-  fromRight undefined
-    . interpret defaultPropositionalLogicInterpreter
-    . fromRight undefined
-    . parseAST
+  interpret defaultPropositionalLogicInterpreter
+    <=< parseAST
 
 rewriteProp :: Ord a => PropFormula a -> Set.Set (PropFormula a)
 rewriteProp = LS.rewrite PropositionalLogic
 
-parseAsPeanoFormula :: String -> Formula PeanoArithmetic String
+parseAsPeanoFormula ::
+  String -> Either EH.Error (Formula PeanoArithmetic String)
 parseAsPeanoFormula =
-  fromRight undefined
-    . interpret defaultPeanoArithmeticInterpreter
-    . fromRight undefined
-    . parseAST
+  interpret defaultPeanoArithmeticInterpreter
+    <=< parseAST
 
 rewritePeano :: Ord a => PeanoFormula a -> Set.Set (PeanoFormula a)
 rewritePeano = LS.rewrite PeanoArithmetic
+
+unRight :: Either a b -> b
+unRight = fromRight undefined

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -6,6 +6,7 @@ import qualified AbstractSyntaxTree as AST
 import Control.Monad (liftM2)
 import qualified Data.Char as Char
 import qualified Data.List as List
+import qualified ErrorHandling as EH
 import Text.Parsec
 import Text.Parsec.Pos (updatePosString)
 
@@ -19,8 +20,10 @@ instance Show ParseTree where
   show (Node x []) = x
   show (Node x ys) = "(" ++ x ++ " " ++ List.unwords (map show ys) ++ ")"
 
-parseAST :: String -> Either ParseError (AST.AST String)
-parseAST str = toAST <$> parseTree str
+parseAST :: String -> Either EH.Error (AST.AST String)
+parseAST str = case parseTree str of
+  Left err -> Left $ EH.parseError err
+  Right result -> Right $ toAST result
   where
     toAST (Node n args) = AST.ast n $ map toAST args
 

--- a/src/PeanoArithmetic.hs
+++ b/src/PeanoArithmetic.hs
@@ -7,6 +7,7 @@
 module PeanoArithmetic where
 
 import qualified Data.Map as Map
+import qualified ErrorHandling as EH
 import qualified Interpreter
 import qualified LogicSystem as LS
 import qualified RApplicative as RApp
@@ -130,10 +131,10 @@ newtype PeanoArithmeticInterpreter a = PeanoArithmeticInterpreter
   { operatorByID ::
       Map.Map
         a
-        ([PeanoFormula a] -> Either Interpreter.InterpretError (PeanoFormula a))
+        ([PeanoFormula a] -> Either EH.Error (PeanoFormula a))
   }
 
-instance Ord a => Interpreter.Interpreter (PeanoArithmeticInterpreter a) a where
+instance Ord a => Interpreter.Interpreter (PeanoArithmeticInterpreter a) a a where
   type LogicSystem (PeanoArithmeticInterpreter a) = PeanoArithmetic
   operatorByID = operatorByID
   variableFromID = const VAR
@@ -150,7 +151,7 @@ defaultPeanoArithmeticInterpreter =
 peanoArithmeticInterpreterFromNames ::
   Ord a =>
   [ ( [PeanoFormula a] ->
-      Either Interpreter.InterpretError (PeanoFormula a),
+      Either EH.Error (PeanoFormula a),
       [a]
     )
   ] ->
@@ -160,14 +161,14 @@ peanoArithmeticInterpreterFromNames =
     . Map.fromList
     . concatMap (\(op, ns) -> map (,op) ns)
 
-zero :: [PeanoFormula a] -> Either Interpreter.InterpretError (PeanoFormula a)
+zero :: [PeanoFormula a] -> Either EH.Error (PeanoFormula a)
 zero = Interpreter.makeConstant ZERO "PeanoArithmetic.ZERO"
 
-succ :: [PeanoFormula a] -> Either Interpreter.InterpretError (PeanoFormula a)
+succ :: [PeanoFormula a] -> Either EH.Error (PeanoFormula a)
 succ = Interpreter.makeUnary S "PeanoArithmetic.S"
 
-plus :: [PeanoFormula a] -> Either Interpreter.InterpretError (PeanoFormula a)
+plus :: [PeanoFormula a] -> Either EH.Error (PeanoFormula a)
 plus = Interpreter.makeBinary PLUS "PeanoArithmetic.PLUS"
 
-times :: [PeanoFormula a] -> Either Interpreter.InterpretError (PeanoFormula a)
+times :: [PeanoFormula a] -> Either EH.Error (PeanoFormula a)
 times = Interpreter.makeBinary TIMES "PeanoArithmetic.TIMES"

--- a/src/PeanoArithmetic.hs
+++ b/src/PeanoArithmetic.hs
@@ -65,7 +65,7 @@ mapFormula f term = f term
 -- Approximate measure of complexity of formula
 -- No rewrite rule should increase this
 complexity :: PeanoFormula a -> Int
-complexity ZERO = 0
+complexity ZERO = 1
 complexity (VAR _) = 1
 complexity (S x) = 1 + complexity x
 complexity (PLUS x y) = 1 + complexity x + complexity y

--- a/src/PropositionalLogic.hs
+++ b/src/PropositionalLogic.hs
@@ -8,6 +8,7 @@ module PropositionalLogic where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified ErrorHandling as EH
 import qualified Interpreter
 import qualified LogicSystem as LS
 import qualified RApplicative as RApp
@@ -237,10 +238,10 @@ newtype PropositionalLogicInterpreter a = PropositionalLogicInterpreter
   { operatorByID ::
       Map.Map
         a
-        ([PropFormula a] -> Either Interpreter.InterpretError (PropFormula a))
+        ([PropFormula a] -> Either EH.Error (PropFormula a))
   }
 
-instance Ord a => Interpreter.Interpreter (PropositionalLogicInterpreter a) a where
+instance Ord a => Interpreter.Interpreter (PropositionalLogicInterpreter a) a a where
   type LogicSystem (PropositionalLogicInterpreter a) = PropositionalLogic
   operatorByID = operatorByID
   variableFromID = const VAR
@@ -259,7 +260,7 @@ defaultPropositionalLogicInterpreter =
 propositionalLogicInterpreterFromNames ::
   Ord a =>
   [ ( [PropFormula a] ->
-      Either Interpreter.InterpretError (PropFormula a),
+      Either EH.Error (PropFormula a),
       [a]
     )
   ] ->
@@ -269,20 +270,20 @@ propositionalLogicInterpreterFromNames =
     . Map.fromList
     . concatMap (\(op, ns) -> map (,op) ns)
 
-true :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+true :: [PropFormula a] -> Either EH.Error (PropFormula a)
 true = Interpreter.makeConstant TRUE "PropositionalLogic.TRUE"
 
-false :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+false :: [PropFormula a] -> Either EH.Error (PropFormula a)
 false = Interpreter.makeConstant FALSE "PropositionalLogic.FALSE"
 
-not :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+not :: [PropFormula a] -> Either EH.Error (PropFormula a)
 not = Interpreter.makeUnary NOT "PropositionalLogic.NOT"
 
-or :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+or :: [PropFormula a] -> Either EH.Error (PropFormula a)
 or = Interpreter.makeBinary OR "PropositionalLogic.OR"
 
-and :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+and :: [PropFormula a] -> Either EH.Error (PropFormula a)
 and = Interpreter.makeBinary AND "PropositionalLogic.AND"
 
-implies :: [PropFormula a] -> Either Interpreter.InterpretError (PropFormula a)
+implies :: [PropFormula a] -> Either EH.Error (PropFormula a)
 implies = Interpreter.makeBinary IMPLIES "PropositionalLogic.IMPLIES"


### PR DESCRIPTION
Error handling is now wrapped up in its own module. The main improvement of this is that we can now (kleisli) compose the interpretation after the parsing. As such, we are most of the way to being able to perform all parts of the "calculator" in a single monadic computation. Additionally, I relaxed the parser to not inspect the names of the operations and arguments in the tree. This means that we can now name things in an AST `"0"` or `"d/dx"`